### PR TITLE
Correct (again) EuroPython link.

### DIFF
--- a/guideline/cfh.md
+++ b/guideline/cfh.md
@@ -333,5 +333,5 @@ remotely and persist from location to location. This framework will help:
 3. encourage the wider APAC community to take part in the organization process
    beside the on-site team
 
-The PyCon APAC framework can take reference from models such as those of
-[EuroPython](http://www.europython-society.org/).
+The PyCon APAC framework can take reference from models such as [those of
+EuroPython](http://www.europython-society.org/post/99718376575/europython-workgroups-call-for-volunteers).


### PR DESCRIPTION
The link in Beng Keat's word file was malformed.  Google helped me to get the correct one.

We probably should consult Beng Keat for what he really meant for that link.  Before he comes to Github and comment, I think we should keep the longer link.
